### PR TITLE
Fix MapScreen geocell import

### DIFF
--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -5,7 +5,7 @@ import * as Location from 'expo-location';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { supabase } from '../lib/supabase';
 import { getDeviceId } from '../utils/device';
-import { toCellId } from '../utils/geocell';
+import { coordsToCellId } from '../utils/geocell';
 
 type LotStatus = 'empty' | 'filling' | 'tight' | 'full' | null;
 type LotRow = { id: string; name: string; lat: number; lng: number; status: LotStatus; confidence: number | null; isFavorite?: boolean };
@@ -154,7 +154,7 @@ export default function MapScreen() {
     const { status: perm } = await Location.requestForegroundPermissionsAsync();
     if (perm !== 'granted') { Alert.alert('Location needed', 'We use your location to create a coarse safety alert.'); return; }
     const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
-    const cell_id = toCellId(loc.coords.latitude, loc.coords.longitude);
+    const cell_id = coordsToCellId(loc.coords.latitude, loc.coords.longitude);
     await supabase.from('pace_reports').insert({ cell_id });
   };
 


### PR DESCRIPTION
## Summary
- fix the MapScreen geocell utility import so the map screen can mount

## Testing
- npm run lint *(fails: You are linting "/workspace/spark/src", but all of the files matching the glob pattern "/workspace/spark/src" are ignored.)*

------
https://chatgpt.com/codex/tasks/task_e_68e28348d8588333a74e4af64c893e58