### PR TITLE
Reset parking MVP without binary assets

### DIFF
--- a/app.json
+++ b/app.json
@@ -4,7 +4,6 @@
     "slug": "spark-msu",
     "version": "1.0.0",
     "orientation": "portrait",
-    "icon": "./assets/images/icon.png",
     "scheme": "sparkmsu",
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
@@ -15,12 +14,6 @@
       }
     },
     "android": {
-      "adaptiveIcon": {
-        "backgroundColor": "#E6F4FE",
-        "foregroundImage": "./assets/images/android-icon-foreground.png",
-        "backgroundImage": "./assets/images/android-icon-background.png",
-        "monochromeImage": "./assets/images/android-icon-monochrome.png"
-      },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,
       "permissions": [
@@ -28,23 +21,10 @@
       ]
     },
     "web": {
-      "output": "static",
-      "favicon": "./assets/images/favicon.png"
+      "output": "static"
     },
     "plugins": [
-      "expo-router",
-      [
-        "expo-splash-screen",
-        {
-          "image": "./assets/images/splash-icon.png",
-          "imageWidth": 200,
-          "resizeMode": "contain",
-          "backgroundColor": "#ffffff",
-          "dark": {
-            "backgroundColor": "#000000"
-          }
-        }
-      ]
+      "expo-router"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
-import { SafeAreaView, StatusBar } from 'react-native';
+import { StatusBar } from 'react-native';
 import MapScreen from '../src/screens/MapScreen';
 
 export default function Index() {
   return (
-    <SafeAreaView style={{ flex: 1 }}>
+    <>
       <StatusBar barStyle="dark-content" />
       <MapScreen />
-    </SafeAreaView>
+    </>
   );
 }

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,13 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 
-const SUPABASE_URL = process.env.EXPO_PUBLIC_SUPABASE_URL;
-const SUPABASE_ANON_KEY = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
+const url = process.env.EXPO_PUBLIC_SUPABASE_URL!;
+const anon = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY!;
 
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
-  throw new Error('Missing Supabase env. Set EXPO_PUBLIC_SUPABASE_URL and EXPO_PUBLIC_SUPABASE_ANON_KEY in .env');
-}
-
-export const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  auth: { persistSession: false, autoRefreshToken: false },
-  realtime: { params: { eventsPerSecond: 10 } },
-});
+export const supabase = createClient(url, anon);

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -1,270 +1,548 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, Modal, Pressable, StyleSheet, Text, View } from 'react-native';
-import MapView, { Marker, Circle, Region } from 'react-native-maps';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Alert,
+  FlatList,
+  Modal,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import MapView, { Circle, Marker } from 'react-native-maps';
 import * as Location from 'expo-location';
-import AsyncStorage from '@react-native-async-storage/async-storage';
+
 import { supabase } from '../lib/supabase';
-import { getDeviceId } from '../utils/device';
-import { coordsToCellId } from '../utils/geocell';
+import { MSU_REGION, distanceMeters, nowMs } from '../utils/geo';
 
-type LotStatus = 'empty' | 'filling' | 'tight' | 'full' | null;
-type LotRow = { id: string; name: string; lat: number; lng: number; status: LotStatus; confidence: number | null; isFavorite?: boolean };
+type LotStatus = 'OPEN' | 'FILLING' | 'FULL';
 
-const MSU_CENTER: Region = { latitude: 42.727, longitude: -84.483, latitudeDelta: 0.03, longitudeDelta: 0.03 };
-const PROXIMITY_M = 150;
-const COOLDOWN_MIN = 20;
-const PACE_DELAY_MIN = 3;
-const PACE_WINDOW_MIN = 45;
+type Lot = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+};
 
-function statusToColor(s: LotStatus) {
-  if (s === 'empty') return '#22c55e';
-  if (s === 'filling') return '#eab308';
-  if (s === 'tight') return '#fb923c';
-  if (s === 'full') return '#ef4444';
-  return '#9ca3af';
-}
-function haversine(lat1:number, lon1:number, lat2:number, lon2:number) {
-  const toRad = (d:number)=> d*Math.PI/180, R = 6371000;
-  const dLat = toRad(lat2-lat1), dLon = toRad(lon2-lon1);
-  const a = Math.sin(dLat/2)**2 + Math.cos(toRad(lat1))*Math.cos(toRad(lat2))*Math.sin(dLon/2)**2;
-  return 2*R*Math.asin(Math.sqrt(a));
-}
-function withinRadius(a:{lat:number,lng:number}, b:{lat:number,lng:number}, meters:number) {
-  return haversine(a.lat,a.lng,b.lat,b.lng) <= meters;
-}
+type Signal = {
+  id: string;
+  lotId: string;
+  status: LotStatus;
+  createdAt: number;
+  source: 'post' | 'agree' | 'update';
+};
+
+type LotConsensus = {
+  status: LotStatus;
+  margin: number;
+  confidence: number;
+  updatedAt: number;
+  pending?: { status: LotStatus; seenAt: number } | null;
+};
+
+const LOT_STATUSES: LotStatus[] = ['OPEN', 'FILLING', 'FULL'];
+
+const STATUS_LABEL: Record<LotStatus, string> = {
+  OPEN: 'OPEN',
+  FILLING: 'FILLING',
+  FULL: 'FULL',
+};
+
+const STATUS_COLOR: Record<LotStatus, string> = {
+  OPEN: '#22c55e',
+  FILLING: '#eab308',
+  FULL: '#ef4444',
+};
+
+const LOTS: Lot[] = [
+  { id: 'lot-7', name: 'Lot 7 (IM East)', lat: 42.72452, lng: -84.47234 },
+  { id: 'lot-15', name: 'Lot 15 (Wharton)', lat: 42.72951, lng: -84.48335 },
+  { id: 'lot-21', name: 'Lot 21 (Spartan Stadium)', lat: 42.72818, lng: -84.48201 },
+  { id: 'lot-23', name: 'Lot 23 (STEM)', lat: 42.73097, lng: -84.4782 },
+  { id: 'lot-24', name: 'Lot 24 (Breslin)', lat: 42.72899, lng: -84.49544 },
+  { id: 'lot-25', name: 'Lot 25 (IM West)', lat: 42.72495, lng: -84.48796 },
+  { id: 'lot-27', name: 'Lot 27 (Engineering)', lat: 42.72644, lng: -84.47886 },
+  { id: 'lot-30', name: 'Lot 30 (Clinical Center)', lat: 42.73263, lng: -84.47874 },
+  { id: 'lot-39', name: 'Lot 39 (Auditorium)', lat: 42.73203, lng: -84.48476 },
+  { id: 'lot-41', name: 'Lot 41 (Agriculture Hall)', lat: 42.72599, lng: -84.48002 },
+  { id: 'lot-53', name: 'Lot 53 (Shaw Ramp)', lat: 42.7268, lng: -84.47938 },
+  { id: 'lot-60', name: 'Lot 60 (Hannah)', lat: 42.73458, lng: -84.49248 },
+  { id: 'lot-62w', name: 'Lot 62W (Bogue Street)', lat: 42.73003, lng: -84.47075 },
+  { id: 'lot-63', name: 'Lot 63 (CATA)', lat: 42.73246, lng: -84.47469 },
+  { id: 'lot-67', name: 'Lot 67 (Kellogg)', lat: 42.73215, lng: -84.48595 },
+  { id: 'lot-75', name: 'Lot 75 (Brody)', lat: 42.73351, lng: -84.49783 },
+  { id: 'lot-79', name: 'Lot 79 (Munn)', lat: 42.72729, lng: -84.48989 },
+  { id: 'lot-91', name: 'Lot 91 (Service Rd)', lat: 42.72176, lng: -84.48538 },
+  { id: 'lot-100', name: 'Lot 100 (Research)', lat: 42.73576, lng: -84.47542 },
+];
+
+const SIGMOID = (x: number) => 1 / (1 + Math.exp(-x));
+
+const INITIAL_CONSENSUS: Record<string, LotConsensus> = LOTS.reduce((acc, lot) => {
+  acc[lot.id] = {
+    status: 'OPEN',
+    margin: 0,
+    confidence: 0.25,
+    updatedAt: nowMs(),
+    pending: null,
+  };
+  return acc;
+}, {} as Record<string, LotConsensus>);
+
+const MAX_SIGNAL_AGE_MIN = 180;
 
 export default function MapScreen() {
-  const [lots, setLots] = useState<LotRow[] | null>(null);
-  const [selected, setSelected] = useState<LotRow | null>(null);
-  const [subscribed, setSubscribed] = useState(false);
-  const [carma, setCarma] = useState<number>(0);
-  const [tier, setTier] = useState<number>(1);
-  const [paceCells, setPaceCells] = useState<{ cell_id: string; created_at: string }[]>([]);
-  const pollRef = useRef<NodeJS.Timer | null>(null);
-  const deviceIdRef = useRef<string | null>(null);
+  const [signals, setSignals] = useState<Signal[]>([]);
+  const [consensus, setConsensus] = useState<Record<string, LotConsensus>>(INITIAL_CONSENSUS);
+  const [selectedLotId, setSelectedLotId] = useState<string | null>(null);
+  const [composer, setComposer] = useState<{ mode: 'post' | 'update'; lotId: string | null } | null>(null);
+  const [clock, setClock] = useState(nowMs());
 
-  useEffect(() => { (async () => { deviceIdRef.current = await getDeviceId(); })(); }, []);
-
-  async function fetchLots() {
-    const { data, error } = await supabase
-      .from('lots')
-      .select('id,name,lat,lng,lot_current(status,confidence),favorites(lot_id)')
-      .returns<any>();
-    if (error) throw error;
-    const rows: LotRow[] = (data ?? []).map((r:any)=> ({
-      id: r.id, name: r.name, lat: r.lat, lng: r.lng,
-      status: r.lot_current?.status ?? null,
-      confidence: r.lot_current?.confidence ?? 0,
-      isFavorite: Array.isArray(r.favorites) && r.favorites.length > 0
-    }));
-    setLots(rows);
-  }
-
-  async function fetchPace() {
-    const { data, error } = await supabase
-      .from('pace_reports')
-      .select('cell_id, created_at')
-      .gte('created_at', new Date(Date.now() - PACE_WINDOW_MIN*60*1000).toISOString());
-    if (!error) setPaceCells(data ?? []);
-  }
-
-  useEffect(() => { fetchLots().catch(console.warn); fetchPace().catch(console.warn); }, []);
-
-  // Realtime lots
   useEffect(() => {
-    const channel = supabase.channel('realtime:lot_current')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'lot_current' }, (payload:any) => {
-        setLots(prev => {
-          if (!prev) return prev;
-          const lotId = payload.new?.lot_id ?? payload.old?.lot_id;
-          const idx = prev.findIndex(l => l.id === lotId);
-          if (idx === -1) return prev;
-          const next = [...prev];
-          next[idx] = { ...next[idx], status: payload.new?.status ?? null, confidence: payload.new?.confidence ?? 0 };
-          return next;
-        });
-      })
-      .subscribe(status => {
-        const ok = status === 'SUBSCRIBED';
-        setSubscribed(ok);
-        if (!ok && !pollRef.current) {
-          pollRef.current = setInterval(()=>fetchLots().catch(()=>{}), 20000);
-        } else if (ok && pollRef.current) {
-          clearInterval(pollRef.current); pollRef.current = null;
-        }
+    const handle = setInterval(() => {
+      setClock(nowMs());
+    }, 30_000);
+    return () => clearInterval(handle);
+  }, []);
+
+  useEffect(() => {
+    setSignals((prev) => {
+      const now = nowMs();
+      return prev.filter((signal) => (now - signal.createdAt) / 60000 <= MAX_SIGNAL_AGE_MIN);
+    });
+  }, [clock]);
+
+  useEffect(() => {
+    setConsensus((prev) => {
+      const now = nowMs();
+      const next: Record<string, LotConsensus> = {};
+      LOTS.forEach((lot) => {
+        const prior = prev[lot.id] ?? INITIAL_CONSENSUS[lot.id];
+        next[lot.id] = computeConsensusForLot(lot.id, prior, signals, now);
       });
-    return () => { supabase.removeChannel(channel); if (pollRef.current) clearInterval(pollRef.current); };
-  }, []);
+      return next;
+    });
+  }, [signals, clock]);
 
-  // Realtime PACE
-  useEffect(() => {
-    const ch = supabase.channel('realtime:pace')
-      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'pace_reports' }, (p:any) => {
-        setPaceCells(prev => [{ cell_id: p.new.cell_id, created_at: p.new.created_at }, ...prev]);
-      })
-      .subscribe();
-    return () => { supabase.removeChannel(ch); };
-  }, []);
+  const selectedLot = useMemo(
+    () => LOTS.find((lot) => lot.id === selectedLotId) ?? null,
+    [selectedLotId]
+  );
+  const selectedConsensus = selectedLot ? consensus[selectedLot.id] : null;
 
-  const onSubmitStatus = async (status: Exclude<LotStatus, null>) => {
-    if (!selected) return;
-    const key = `spark:cooldown:${selected.id}`;
-    const now = Date.now();
-    const existing = await AsyncStorage.getItem(key);
-    if (existing) {
-      const until = parseInt(existing,10);
-      if (until > now) {
-        const remaining = Math.max(0, Math.round((until-now)/1000));
-        const mm = String(Math.floor(remaining/60)).padStart(2,'0');
-        const ss = String(remaining%60).padStart(2,'0');
-        Alert.alert('Cooldown', `Try again in ${mm}:${ss}`); return;
-      }
+  const ensurePresence = useCallback(async (lot: Lot) => {
+    const perm = await Location.requestForegroundPermissionsAsync();
+    if (perm.status !== 'granted') {
+      Alert.alert('Location required', 'Allow location to post accurate lot updates.');
+      return null;
     }
-    const { status: perm } = await Location.requestForegroundPermissionsAsync();
-    if (perm !== 'granted') { Alert.alert('Location needed', 'We use your location to verify reports near lots.'); return; }
     const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
     const here = { lat: loc.coords.latitude, lng: loc.coords.longitude };
-    const lot = { lat: selected.lat, lng: selected.lng };
-    if (!withinRadius(here, lot, PROXIMITY_M)) { Alert.alert('Too far', 'You need to be near this lot to report.'); return; }
-
-    const device_id = deviceIdRef.current ?? (await getDeviceId());
-    setLots(prev => prev?.map(l => l.id === selected.id ? { ...l, status } : l) ?? prev);
-    const { error } = await supabase.from('lot_status_reports').insert({
-      lot_id: selected.id, status, device_id, lat: here.lat, lng: here.lng
-    });
-    if (error) { Alert.alert('Failed', error.message); return; }
-
-    // carma +10
-    try {
-      const res = await fetch(`${process.env.EXPO_PUBLIC_SUPABASE_URL}/functions/v1/apply_carma`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY}` },
-        body: JSON.stringify({ device_id, delta: 10, reason: 'lot_report' })
-      });
-      const json = await res.json().catch(()=>null);
-      if (json && typeof json.carma === 'number') { setCarma(json.carma); setTier(json.tier ?? 1); }
-    } catch {}
-
-    const until = now + COOLDOWN_MIN*60*1000;
-    await AsyncStorage.setItem(key, String(until));
-    setSelected(null);
-  };
-
-  const onPace = async () => {
-    const { status: perm } = await Location.requestForegroundPermissionsAsync();
-    if (perm !== 'granted') { Alert.alert('Location needed', 'We use your location to create a coarse safety alert.'); return; }
-    const loc = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
-    const cell_id = coordsToCellId(loc.coords.latitude, loc.coords.longitude);
-    await supabase.from('pace_reports').insert({ cell_id });
-  };
-
-  const toggleFavorite = async (lot: LotRow) => {
-    if (!lots) return;
-    const currentlyFav = !!lot.isFavorite;
-    if (currentlyFav) {
-      await supabase.from('favorites').delete().eq('lot_id', lot.id);
-    } else {
-      await supabase.from('favorites').insert({ lot_id: lot.id });
+    const distance = distanceMeters(here, { lat: lot.lat, lng: lot.lng });
+    if (distance > 200) {
+      Alert.alert('Too far away', 'You must be within 200 meters of this lot to submit.');
+      return null;
     }
-    setLots(prev => prev?.map(l => l.id === lot.id ? { ...l, isFavorite: !currentlyFav } : l) ?? prev);
-  };
+    return { here, distance };
+  }, []);
 
-  const visiblePace = useMemo(() => {
-    const now = Date.now();
-    return paceCells.filter(c => {
-      const t = new Date(c.created_at).getTime();
-      const ageMin = (now - t)/60000;
-      return ageMin >= PACE_DELAY_MIN && ageMin <= PACE_WINDOW_MIN;
-    });
-  }, [paceCells]);
+  const pushSignal = useCallback(
+    async (lot: Lot, status: LotStatus, source: Signal['source']) => {
+      const timestamp = nowMs();
+      const entry: Signal = {
+        id: `${lot.id}-${timestamp}-${Math.random().toString(36).slice(2, 8)}`,
+        lotId: lot.id,
+        status,
+        createdAt: timestamp,
+        source,
+      };
+      setSignals((prev) => [...prev, entry]);
+      try {
+        await supabase.from('parking_signals').insert({
+          lot_id: lot.id,
+          status,
+          source,
+          recorded_at: new Date(timestamp).toISOString(),
+        });
+      } catch (error) {
+        console.warn('Supabase signal insert failed', error);
+      }
+    },
+    []
+  );
 
-  const content = useMemo(() => {
-    if (!lots) return <ActivityIndicator style={{ marginTop: 24 }} />;
-    return (
-      <MapView style={{ flex: 1 }} initialRegion={MSU_CENTER}>
-        {lots.map(l => (
-          <React.Fragment key={l.id}>
-            <Marker
-              coordinate={{ latitude: l.lat, longitude: l.lng }}
-              title={l.name}
-              pinColor={statusToColor(l.status)}
-              onCalloutPress={() => toggleFavorite(l)}
-              onPress={() => setSelected(l)}
-              description={l.isFavorite ? '★ Favorite' : 'Tap to set status • Tap callout to star'}
-            />
-            {!!l.confidence && l.confidence > 0 && (
-              <Circle
-                center={{ latitude: l.lat, longitude: l.lng }}
-                radius={50 + 100 * Math.min(1, Number(l.confidence))}
-                strokeColor="rgba(59,130,246,0.25)"
-                fillColor="rgba(59,130,246,0.12)"
-              />
-            )}
-          </React.Fragment>
-        ))}
-        {visiblePace.map((c, i) => {
-          const [latStr,lngStr] = c.cell_id.split(',');
-          const lat = parseFloat(latStr), lng = parseFloat(lngStr);
-          if (Number.isNaN(lat) || Number.isNaN(lng)) return null;
+  const handleAgree = useCallback(async () => {
+    if (!selectedLot || !selectedConsensus) return;
+    const presence = await ensurePresence(selectedLot);
+    if (!presence) return;
+    await pushSignal(selectedLot, selectedConsensus.status, 'agree');
+    setSelectedLotId(null);
+  }, [ensurePresence, pushSignal, selectedConsensus, selectedLot]);
+
+  const handleComposerStatus = useCallback(
+    async (status: LotStatus) => {
+      if (!composer) return;
+      const lot = composer.lotId
+        ? LOTS.find((item) => item.id === composer.lotId)
+        : null;
+      if (!lot) return;
+      const presence = await ensurePresence(lot);
+      if (!presence) return;
+      await pushSignal(lot, status, composer.mode === 'post' ? 'post' : 'update');
+      setComposer(null);
+    },
+    [composer, ensurePresence, pushSignal]
+  );
+
+  const handleUpdateFromSheet = useCallback(() => {
+    if (!selectedLot) return;
+    setComposer({ mode: 'update', lotId: selectedLot.id });
+    setSelectedLotId(null);
+  }, [selectedLot]);
+
+  const openPostComposer = useCallback(() => {
+    setComposer({ mode: 'post', lotId: null });
+  }, []);
+
+  const composerLot = useMemo(() => {
+    if (!composer) return null;
+    if (!composer.lotId) return null;
+    return LOTS.find((lot) => lot.id === composer.lotId) ?? null;
+  }, [composer]);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <MapView style={styles.map} initialRegion={MSU_REGION}>
+        {LOTS.map((lot) => {
+          const snapshot = consensus[lot.id] ?? INITIAL_CONSENSUS[lot.id];
+          const minutesAgo = Math.max(0, Math.round((clock - snapshot.updatedAt) / 60000));
+          const timeLabel = minutesAgo < 1 ? 'Just now' : `${minutesAgo}m ago`;
+          const confidence = snapshot.confidence;
+          const radius = 70 + 140 * confidence;
+          const isConfident = confidence >= 0.6;
           return (
-            <Circle
-              key={`${c.cell_id}-${i}`}
-              center={{ latitude: lat, longitude: lng }}
-              radius={220}
-              strokeColor="rgba(239,68,68,0.25)"
-              fillColor="rgba(239,68,68,0.12)"
-            />
+            <React.Fragment key={lot.id}>
+              <Marker coordinate={{ latitude: lot.lat, longitude: lot.lng }} onPress={() => setSelectedLotId(lot.id)}>
+                <View style={styles.markerPill}>
+                  <Text style={[styles.markerText, { color: STATUS_COLOR[snapshot.status] }]}>
+                    [{STATUS_LABEL[snapshot.status]}]
+                  </Text>
+                  <Text style={styles.markerSub}>{timeLabel}</Text>
+                </View>
+              </Marker>
+              <Circle
+                center={{ latitude: lot.lat, longitude: lot.lng }}
+                radius={radius}
+                strokeColor="rgba(37, 99, 235, 0.65)"
+                strokeWidth={2}
+                strokeDasharray={isConfident ? undefined : [12, 8]}
+                fillColor="rgba(37, 99, 235, 0.08)"
+              />
+            </React.Fragment>
           );
         })}
       </MapView>
-    );
-  }, [lots, visiblePace]);
 
-  return (
-    <View style={{ flex: 1 }}>
-      {/* header chip */}
-      <View style={styles.header}>
-        <Text style={styles.headerText}>Carma: {carma}  ·  Tier {tier}</Text>
-      </View>
-      {content}
-      {/* status sheet */}
-      <Modal visible={!!selected} transparent animationType="fade" onRequestClose={()=>setSelected(null)}>
-        <View style={styles.modalWrap}>
+      <Pressable style={styles.fab} onPress={openPostComposer} accessibilityRole="button" accessibilityLabel="Report parking status">
+        <Text style={styles.fabText}>+</Text>
+      </Pressable>
+
+      <Modal transparent animationType="fade" visible={!!selectedLot} onRequestClose={() => setSelectedLotId(null)}>
+        <View style={styles.backdrop}>
           <View style={styles.sheet}>
-            <Text style={styles.title}>{selected?.name}</Text>
-            <View style={styles.row}>
-              <Pressable style={[styles.btn,{backgroundColor:'#22c55e'}]} onPress={()=>onSubmitStatus('empty')}><Text style={styles.btnText}>Empty</Text></Pressable>
-              <Pressable style={[styles.btn,{backgroundColor:'#eab308'}]} onPress={()=>onSubmitStatus('filling')}><Text style={styles.btnText}>Filling</Text></Pressable>
+            <Text style={styles.sheetTitle}>{selectedLot?.name}</Text>
+            <Text style={styles.sheetStatusLabel}>
+              Current: {selectedConsensus ? STATUS_LABEL[selectedConsensus.status] : 'OPEN'}
+            </Text>
+            <View style={styles.sheetActions}>
+              <Pressable style={[styles.actionBtn, styles.agree]} onPress={handleAgree}>
+                <Text style={styles.actionText}>Agree</Text>
+              </Pressable>
+              <Pressable style={[styles.actionBtn, styles.update]} onPress={handleUpdateFromSheet}>
+                <Text style={styles.actionText}>Update</Text>
+              </Pressable>
             </View>
-            <View style={styles.row}>
-              <Pressable style={[styles.btn,{backgroundColor:'#fb923c'}]} onPress={()=>onSubmitStatus('tight')}><Text style={styles.btnText}>Tight</Text></Pressable>
-              <Pressable style={[styles.btn,{backgroundColor:'#ef4444'}]} onPress={()=>onSubmitStatus('full')}><Text style={styles.btnText}>Full</Text></Pressable>
-            </View>
-            <Pressable style={styles.cancel} onPress={()=>setSelected(null)}><Text style={{color:'#111827'}}>Cancel</Text></Pressable>
-            <Text style={styles.hint}>{subscribed ? 'Live' : 'Reconnecting… polling every 20s'}</Text>
+            <Pressable style={styles.closeBtn} onPress={() => setSelectedLotId(null)}>
+              <Text style={styles.closeText}>Cancel</Text>
+            </Pressable>
           </View>
         </View>
       </Modal>
 
-      {/* PACE FAB */}
-      <Pressable onPress={onPace} style={styles.fab}>
-        <Text style={styles.fabText}>PACE</Text>
-      </Pressable>
-    </View>
+      <Modal
+        transparent
+        animationType="slide"
+        visible={!!composer}
+        onRequestClose={() => setComposer(null)}
+      >
+        <View style={styles.backdrop}>
+          <View style={styles.composer}>
+            <Text style={styles.composerTitle}>
+              {composer?.mode === 'update' ? 'Update lot status' : 'Post parking status'}
+            </Text>
+            {!composerLot && (
+              <View style={styles.listContainer}>
+                <Text style={styles.listHeader}>Pick a lot</Text>
+                <FlatList
+                  data={LOTS}
+                  keyExtractor={(item) => item.id}
+                  renderItem={({ item }) => (
+                    <Pressable
+                      style={styles.listItem}
+                      onPress={() => setComposer((prev) => (prev ? { ...prev, lotId: item.id } : prev))}
+                    >
+                      <Text style={styles.listItemName}>{item.name}</Text>
+                      <Text style={styles.listItemMeta}>Tap to choose</Text>
+                    </Pressable>
+                  )}
+                />
+              </View>
+            )}
+            {composerLot && (
+              <View>
+                <Text style={styles.selectedLot}>{composerLot.name}</Text>
+                <View style={styles.statusRow}>
+                  {LOT_STATUSES.map((status) => (
+                    <Pressable
+                      key={status}
+                      style={[styles.statusBtn, { borderColor: STATUS_COLOR[status] }]}
+                      onPress={() => handleComposerStatus(status)}
+                    >
+                      <Text style={[styles.statusBtnText, { color: STATUS_COLOR[status] }]}>
+                        {STATUS_LABEL[status]}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+              </View>
+            )}
+            <Pressable style={styles.closeComposer} onPress={() => setComposer(null)}>
+              <Text style={styles.closeText}>Close</Text>
+            </Pressable>
+          </View>
+        </View>
+      </Modal>
+    </SafeAreaView>
   );
 }
 
+function computeConsensusForLot(
+  lotId: string,
+  prior: LotConsensus,
+  signals: Signal[],
+  now: number
+): LotConsensus {
+  const relevant = signals.filter((signal) => signal.lotId === lotId);
+  const fresh = relevant.filter((signal) => (now - signal.createdAt) / 60000 <= MAX_SIGNAL_AGE_MIN);
+  const weights: Record<LotStatus, number> = {
+    OPEN: 0,
+    FILLING: 0,
+    FULL: 0,
+  };
+
+  fresh.forEach((signal) => {
+    const ageMin = (now - signal.createdAt) / 60000;
+    const weight = Math.exp(-ageMin / 15);
+    weights[signal.status] += weight;
+  });
+
+  const ordered = LOT_STATUSES.map((status) => ({ status, weight: weights[status] })).sort(
+    (a, b) => b.weight - a.weight
+  );
+
+  const top = ordered[0];
+  const runner = ordered[1];
+  const margin = Math.max(0, top.weight - (runner?.weight ?? 0));
+  const hasSignals = fresh.length > 0;
+  const confidence = hasSignals ? SIGMOID(6 * margin) : 0.25;
+
+  let status = prior.status;
+  let pending = prior.pending ?? null;
+  let updatedAt = prior.updatedAt;
+
+  if (top.weight === 0 && !hasSignals) {
+    pending = null;
+  } else if (top.status === prior.status) {
+    pending = null;
+  } else if (margin > 0) {
+    if (pending && pending.status === top.status) {
+      status = top.status;
+      pending = null;
+      updatedAt = now;
+    } else {
+      pending = { status: top.status, seenAt: now };
+    }
+  } else {
+    pending = null;
+  }
+
+  return {
+    status,
+    margin,
+    confidence,
+    updatedAt,
+    pending,
+  };
+}
+
 const styles = StyleSheet.create({
-  header:{ position:'absolute', top:16, left:16, zIndex:2, backgroundColor:'rgba(17,24,39,0.85)', paddingHorizontal:12, paddingVertical:6, borderRadius:12 },
-  headerText:{ color:'white', fontWeight:'700' },
-  modalWrap:{flex:1,backgroundColor:'rgba(0,0,0,0.3)',justifyContent:'center',alignItems:'center',padding:16},
-  sheet:{backgroundColor:'white',borderRadius:16,padding:16,width:'100%',maxWidth:360},
-  title:{fontSize:18,fontWeight:'600',marginBottom:12,textAlign:'center'},
-  row:{flexDirection:'row',gap:12,justifyContent:'space-between',marginBottom:12},
-  btn:{flex:1,paddingVertical:14,borderRadius:12,alignItems:'center'},
-  btnText:{color:'white',fontWeight:'700'},
-  cancel:{paddingVertical:12,alignItems:'center',borderRadius:10,backgroundColor:'#e5e7eb'},
-  hint:{textAlign:'center',marginTop:8,color:'#6b7280',fontSize:12},
-  fab:{ position:'absolute', right:16, bottom:30, backgroundColor:'#ef4444', paddingHorizontal:18, paddingVertical:14, borderRadius:24, elevation:6 },
-  fabText:{ color:'white', fontWeight:'800', letterSpacing:1 }
+  container: {
+    flex: 1,
+    backgroundColor: '#f5f5f5',
+  },
+  map: {
+    flex: 1,
+  },
+  markerPill: {
+    backgroundColor: 'white',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#e5e7eb',
+    alignItems: 'center',
+    gap: 4,
+  },
+  markerText: {
+    fontWeight: '700',
+  },
+  markerSub: {
+    fontSize: 12,
+    color: '#4b5563',
+  },
+  fab: {
+    position: 'absolute',
+    right: 20,
+    bottom: 32,
+    backgroundColor: '#111827',
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    alignItems: 'center',
+    justifyContent: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 8,
+  },
+  fabText: {
+    color: 'white',
+    fontSize: 28,
+    fontWeight: '700',
+    marginTop: -4,
+  },
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 20,
+  },
+  sheet: {
+    width: '100%',
+    maxWidth: 360,
+    backgroundColor: 'white',
+    borderRadius: 20,
+    padding: 20,
+    gap: 12,
+  },
+  sheetTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  sheetStatusLabel: {
+    textAlign: 'center',
+    color: '#6b7280',
+  },
+  sheetActions: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  actionBtn: {
+    flex: 1,
+    paddingVertical: 14,
+    borderRadius: 14,
+    alignItems: 'center',
+  },
+  agree: {
+    backgroundColor: '#16a34a',
+  },
+  update: {
+    backgroundColor: '#f59e0b',
+  },
+  actionText: {
+    color: 'white',
+    fontWeight: '700',
+  },
+  closeBtn: {
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: '#e5e7eb',
+    alignItems: 'center',
+  },
+  closeText: {
+    color: '#111827',
+    fontWeight: '600',
+  },
+  composer: {
+    width: '100%',
+    maxWidth: 380,
+    backgroundColor: 'white',
+    borderRadius: 24,
+    padding: 20,
+    gap: 16,
+  },
+  composerTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    textAlign: 'center',
+  },
+  listContainer: {
+    maxHeight: 280,
+  },
+  listHeader: {
+    fontWeight: '600',
+    marginBottom: 12,
+  },
+  listItem: {
+    paddingVertical: 12,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: '#e5e7eb',
+  },
+  listItemName: {
+    fontWeight: '600',
+    color: '#111827',
+  },
+  listItemMeta: {
+    fontSize: 12,
+    color: '#6b7280',
+  },
+  selectedLot: {
+    fontWeight: '700',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  statusRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  statusBtn: {
+    flex: 1,
+    borderWidth: 2,
+    borderRadius: 14,
+    paddingVertical: 14,
+    alignItems: 'center',
+  },
+  statusBtnText: {
+    fontWeight: '700',
+  },
+  closeComposer: {
+    paddingVertical: 12,
+    alignItems: 'center',
+    backgroundColor: '#f3f4f6',
+    borderRadius: 12,
+  },
 });

--- a/src/utils/geo.ts
+++ b/src/utils/geo.ts
@@ -1,0 +1,24 @@
+export const MSU_REGION = {
+  latitude: 42.727,
+  longitude: -84.483,
+  latitudeDelta: 0.03,
+  longitudeDelta: 0.03,
+};
+
+export function distanceMeters(
+  a: { lat: number; lng: number },
+  b: { lat: number; lng: number }
+) {
+  const toRad = (deg: number) => (deg * Math.PI) / 180;
+  const R = 6_371_000;
+  const dLat = toRad(b.lat - a.lat);
+  const dLon = toRad(b.lng - a.lng);
+  const s1 = toRad(a.lat);
+  const s2 = toRad(b.lat);
+  const x =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(s1) * Math.cos(s2) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(x));
+}
+
+export const nowMs = () => Date.now();


### PR DESCRIPTION
## Summary
- point app entry to the parking map MVP and simplify the Supabase client export
- add geo utilities and implement the parking-only MapScreen with seeded MSU lots, consensus decay, and posting/verification flows
- strip icon and splash asset references from app.json so the project uses Expo defaults

## Testing
- npm run lint *(fails: Expo lint configuration ignores src paths in this repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e2b27e145c8333866aa3794ed43875