### PR TITLE
feat: add searchable lot dataset

### DIFF
--- a/src/data/lots.ts
+++ b/src/data/lots.ts
@@ -1,0 +1,29 @@
+export type Lot = {
+  id: string;
+  name: string;
+  lat: number;
+  lng: number;
+};
+
+export const LOTS: Lot[] = [
+  { id: 'lot_89', name: 'Lot 89 (Commuter)', lat: 42.7241, lng: -84.4822 },
+  { id: 'lot_63', name: 'Lot 63', lat: 42.725, lng: -84.4793 },
+  { id: 'lot_91', name: 'Lot 91', lat: 42.7305, lng: -84.4821 },
+  { id: 'lot_83', name: 'Wharton Ramp (Lot 83)', lat: 42.7278, lng: -84.4735 },
+  { id: 'lot_79', name: 'Spartan Stadium (79)', lat: 42.728, lng: -84.4848 },
+  { id: 'lot_62', name: 'IM West (62)', lat: 42.7312, lng: -84.492 },
+  { id: 'lot_67', name: 'Breslin (67)', lat: 42.7282, lng: -84.4925 },
+  { id: 'lot_92', name: 'Comm Arts (92)', lat: 42.7225, lng: -84.474 },
+  { id: 'lot_39', name: 'Engineering (39)', lat: 42.7245, lng: -84.478 },
+  { id: 'lot_40', name: 'Chemistry (40)', lat: 42.726, lng: -84.4765 },
+  { id: 'lot_47', name: 'Library (47)', lat: 42.731, lng: -84.483 },
+  { id: 'lot_61', name: 'Kellogg (61)', lat: 42.722, lng: -84.488 },
+  { id: 'ramp_1', name: 'Ramp 1 (100)', lat: 42.7265, lng: -84.481 },
+  { id: 'ramp_2', name: 'Ramp 2 (101)', lat: 42.729, lng: -84.4805 },
+  { id: 'ramp_3', name: 'Ramp 3 (102)', lat: 42.7275, lng: -84.477 },
+  { id: 'ramp_4', name: 'Ramp 4 (103)', lat: 42.7255, lng: -84.485 },
+  { id: 'ramp_5', name: 'Ramp 5 (104)', lat: 42.73, lng: -84.4785 },
+  { id: 'ramp_6', name: 'Ramp 6 (105)', lat: 42.7235, lng: -84.49 },
+  { id: 'ramp_7', name: 'Ramp 7 (106)', lat: 42.7285, lng: -84.4865 },
+  { id: 'lot_62w', name: 'IM West West (62W)', lat: 42.7315, lng: -84.493 },
+];


### PR DESCRIPTION
## Summary
- add a reusable lot dataset in `src/data/lots.ts`
- update the map screen with search, filtering, and focused marker highlighting
- limit rendered markers to nearby lots and add a long-press debug logger

## Testing
- npm run lint *(fails: ESLint ignores /workspace/spark/src per current config)*

------
https://chatgpt.com/codex/tasks/task_e_68e2de6497608333bf2d7484187cca81