### PR TITLE
Add bottom nav and update map screen FAB icon

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { View, Text, Pressable, StyleSheet, Platform } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+type Props = {
+  onMap?: () => void;
+  onSearch?: () => void;
+  onFavs?: () => void;
+  active?: 'map' | 'search' | 'favs';
+};
+
+export default function BottomNav({ onMap, onSearch, onFavs, active = 'map' }: Props) {
+  return (
+    <SafeAreaView style={styles.wrap} edges={['bottom']}>
+      <View style={styles.row}>
+        <Tab label="Map"    active={active === 'map'}    onPress={onMap} />
+        <Tab label="Search" active={active === 'search'} onPress={onSearch} />
+        <Tab label="Favs"   active={active === 'favs'}   onPress={onFavs} />
+      </View>
+    </SafeAreaView>
+  );
+}
+
+function Tab({ label, active, onPress }: { label: string; active?: boolean; onPress?: () => void }) {
+  return (
+    <Pressable onPress={onPress} style={({ pressed }) => [styles.tab, pressed && { opacity: 0.7 }]}>
+      <Text style={[styles.tabText, active && styles.tabTextActive]}>{label}</Text>
+    </Pressable>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    position: 'absolute',
+    left: 0, right: 0, bottom: 0,
+    backgroundColor: 'white',
+    borderTopWidth: 1, borderTopColor: '#E5E7EB',
+    paddingBottom: Platform.OS === 'android' ? 8 : 0,
+  },
+  row: {
+    height: 56,
+    paddingHorizontal: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-around',
+  },
+  tab: {
+    paddingHorizontal: 16, paddingVertical: 8, borderRadius: 10,
+  },
+  tabText: {
+    fontWeight: '700', color: '#6B7280',
+  },
+  tabTextActive: {
+    color: '#0F2F27',
+  },
+});

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -15,11 +15,17 @@ import {
 import MapView, { Marker, Circle, type Region } from 'react-native-maps';
 import * as Location from 'expo-location';
 
-const APP_ICON = require('../../assets/icon.png');
+let SPARK_ICON: any;
+try {
+  SPARK_ICON = require('../../assets/spark_icon_bolt_1024.png');
+} catch {
+  SPARK_ICON = require('../../assets/icon.png');
+}
 
 import { supabase } from '../lib/supabase';
 import { LOTS } from '../data/lots';
 import { MSU_REGION, distanceMeters, nowMs } from '../utils/geo';
+import BottomNav from '../components/BottomNav';
 
 type LotStatus = 'OPEN' | 'FILLING' | 'FULL';
 
@@ -230,6 +236,15 @@ export default function MapScreen() {
     setComposer({ mode: 'post', lotId: null });
   }, []);
 
+  const handlePressSearchTab = useCallback(() => {
+    setIsSearchFocused(true);
+    searchInputRef.current?.focus();
+  }, []);
+
+  const handlePressFavsTab = useCallback(() => {
+    // TODO: open favorites modal
+  }, []);
+
   const composerLot = useMemo(() => {
     if (!composer) return null;
     if (!composer.lotId) return null;
@@ -315,6 +330,13 @@ export default function MapScreen() {
         </View>
       </View>
 
+      <BottomNav
+        active="map"
+        onMap={() => {}}
+        onSearch={handlePressSearchTab}
+        onFavs={handlePressFavsTab}
+      />
+
       <Pressable
         accessibilityRole="button"
         accessibilityLabel="Create Spark"
@@ -326,7 +348,7 @@ export default function MapScreen() {
         android_ripple={{ color: 'rgba(255,255,255,0.15)', borderless: true }}
         hitSlop={8}
       >
-        <Image source={APP_ICON} resizeMode="contain" style={styles.fabIcon} />
+        <Image source={SPARK_ICON} resizeMode="contain" style={styles.fabIcon} />
       </Pressable>
 
       <Modal transparent animationType="fade" visible={!!selectedLot} onRequestClose={() => setSelectedLotId(null)}>
@@ -556,7 +578,7 @@ const styles = StyleSheet.create({
   fab: {
     position: 'absolute',
     right: 16,
-    bottom: 24,
+    bottom: 72,
     width: 56,
     height: 56,
     borderRadius: 28,


### PR DESCRIPTION
## Summary
- add a reusable BottomNav component with placeholder handlers for future navigation
- update MapScreen to render the bottom nav, focus search from the tab, and lift the FAB above it
- swap the FAB graphic to the Spark bolt asset with a fallback icon

## Testing
- npm run lint *(fails: ESLint reports that /workspace/spark/src is ignored)*

------
https://chatgpt.com/codex/tasks/task_e_68e2e67e851083339f48d4891224795d