### PR TITLE
Rename composer title to Spark

### DIFF
--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -382,7 +382,7 @@ export default function MapScreen() {
         <View style={styles.backdrop}>
           <View style={styles.composer}>
             <Text style={styles.composerTitle}>
-              {composer?.mode === 'update' ? 'Update lot status' : 'Post parking status'}
+              {composer?.mode === 'update' ? 'Update lot status' : 'Spark'}
             </Text>
             {!composerLot && (
               <View style={styles.listContainer}>


### PR DESCRIPTION
## Summary
- rename the composer modal title to Spark when creating a post

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e302007bc0833392a244c0a56217b0