### PR TITLE
Deduplicate lot type declarations

### DIFF
--- a/src/hooks/useRealtimeLots.ts
+++ b/src/hooks/useRealtimeLots.ts
@@ -14,7 +14,7 @@ type LotCurrentRow = {
 
 export type LotStatus = 'empty' | 'filling' | 'tight' | 'full' | string;
 
-export type Lot = {
+export type RealtimeLot = {
   id: number;
   name: string;
   lat: number;
@@ -47,7 +47,7 @@ const normalizeLotCurrent = (value: RawLotRow['lot_current']): LotCurrentRow | n
 };
 
 export type UseRealtimeLotsResult = {
-  lots: Lot[];
+  lots: RealtimeLot[];
   isLoading: boolean;
   error: PostgrestError | null;
   isRealtimeConnected: boolean;
@@ -56,7 +56,7 @@ export type UseRealtimeLotsResult = {
 };
 
 export const useRealtimeLots = (): UseRealtimeLotsResult => {
-  const [lots, setLots] = useState<Lot[]>([]);
+  const [lots, setLots] = useState<RealtimeLot[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [error, setError] = useState<PostgrestError | null>(null);
   const [isRealtimeConnected, setIsRealtimeConnected] = useState<boolean>(false);
@@ -71,7 +71,7 @@ export const useRealtimeLots = (): UseRealtimeLotsResult => {
     };
   }, []);
 
-  const mapLots = useCallback((rows: RawLotRow[]): Lot[] => {
+  const mapLots = useCallback((rows: RawLotRow[]): RealtimeLot[] => {
     return rows.map((row) => {
       const current = normalizeLotCurrent(row.lot_current);
 

--- a/src/screens/MapScreen.tsx
+++ b/src/screens/MapScreen.tsx
@@ -27,33 +27,33 @@ import { msuLots, type Lot } from '../data/lots';
 import { MSU_REGION, distanceMeters, nowMs } from '../utils/geo';
 import BottomNav from '../components/BottomNav';
 
-type LotStatus = 'OPEN' | 'FILLING' | 'FULL';
+type ParkingState = 'OPEN' | 'FILLING' | 'FULL';
 
 type Signal = {
   id: string;
   lotId: string;
-  status: LotStatus;
+  status: ParkingState;
   createdAt: number;
   source: 'post' | 'agree' | 'update';
 };
 
 type LotConsensus = {
-  status: LotStatus;
+  status: ParkingState;
   margin: number;
   confidence: number;
   updatedAt: number;
-  pending?: { status: LotStatus; seenAt: number } | null;
+  pending?: { status: ParkingState; seenAt: number } | null;
 };
 
-const LOT_STATUSES: LotStatus[] = ['OPEN', 'FILLING', 'FULL'];
+const LOT_STATUSES: ParkingState[] = ['OPEN', 'FILLING', 'FULL'];
 
-const STATUS_LABEL: Record<LotStatus, string> = {
+const STATUS_LABEL: Record<ParkingState, string> = {
   OPEN: 'OPEN',
   FILLING: 'FILLING',
   FULL: 'FULL',
 };
 
-const STATUS_COLOR: Record<LotStatus, string> = {
+const STATUS_COLOR: Record<ParkingState, string> = {
   OPEN: '#22c55e',
   FILLING: '#eab308',
   FULL: '#ef4444',
@@ -177,7 +177,7 @@ export default function MapScreen() {
   }, []);
 
   const pushSignal = useCallback(
-    async (lot: Lot, status: LotStatus, source: Signal['source']) => {
+    async (lot: Lot, status: ParkingState, source: Signal['source']) => {
       const timestamp = nowMs();
       const entry: Signal = {
         id: `${lot.id}-${timestamp}-${Math.random().toString(36).slice(2, 8)}`,
@@ -210,7 +210,7 @@ export default function MapScreen() {
   }, [ensurePresence, pushSignal, selectedConsensus, selectedLot]);
 
   const handleComposerStatus = useCallback(
-    async (status: LotStatus) => {
+    async (status: ParkingState) => {
       if (!composer) return;
       const lot = composer.lotId
         ? msuLots.find((item) => item.id === composer.lotId)
@@ -436,7 +436,7 @@ function computeConsensusForLot(
 ): LotConsensus {
   const relevant = signals.filter((signal) => signal.lotId === lotId);
   const fresh = relevant.filter((signal) => (now - signal.createdAt) / 60000 <= MAX_SIGNAL_AGE_MIN);
-  const weights: Record<LotStatus, number> = {
+  const weights: Record<ParkingState, number> = {
     OPEN: 0,
     FILLING: 0,
     FULL: 0,


### PR DESCRIPTION
## Summary
- update MapScreen to rely on the shared Lot interface and rename its local status alias to ParkingState
- rename the hook-specific Lot type in useRealtimeLots to RealtimeLot so it no longer collides with the canonical type

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e3c23b27888333a87ab399821fcc55